### PR TITLE
Change schema to use vanilla GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,4 @@ When you make a new PR, make sure the following checks pass.
 - Backend
   - Express.js: server side framework
   - Apollo Server: GraphQL server
-  - Nexus: Code-First GraphQL library
   - Mongoose: MongoDB client for Node.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -8039,14 +8039,6 @@
         }
       }
     },
-    "nexus": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/nexus/-/nexus-0.11.4.tgz",
-      "integrity": "sha512-2+fuPQ+sxRgq5HEhWN9fmNaOD6KKQgb4+eEgiuI0xDl5ud9mX87J4UP6KEv6fct3Wk8EJ1mZD58MlsvOiSN4+A==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "isomorphic-unfetch": "^3.0.0",
     "mongoose": "^5.4.19",
     "next": "^8.0.3",
-    "nexus": "^0.11.4",
     "pino": "^5.11.3",
     "react": "^16.8.4",
     "react-apollo": "^2.5.2",


### PR DESCRIPTION
Replaced nexus code with vanilla GraphQL code. There is a Root Query and a Mutation, each with only one field at this time. Of course, we will update with new fields as we go. Also, we may create a new object type at some point. This is just a basic working schema.