### PR TITLE
Add npm script for collecting test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ When you make a new PR, make sure the following checks pass.
 - Format: `npm run format:check`  
   If format check fails, you can run `npm run format` to automatically format all the code.
 
+Optinally you can run `npm run coverage` to measure code coverage.
+
 ## Tech Stack
 
 - Frontend

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,15 @@
 module.exports = {
   setupFiles: ["<rootDir>/jest.setup.js"],
-  testPathIgnorePatterns: ["<rootDir>/client/.next/", "<rootDir>/node_modules/"]
+  testPathIgnorePatterns: [
+    "<rootDir>/client/.next/",
+    "<rootDir>/node_modules/"
+  ],
+  collectCoverageFrom: [
+    "**/*.{js,jsx}",
+    "!**/node_modules/**",
+    "!client/.next/**",
+    "!client/next.config.js",
+    "!coverage/**",
+    "!jest.config.js"
+  ]
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write \"**/*.{js,jsx,json,md,yml,yaml,html,graphql}\"",
     "format:check": "prettier --list-different \"**/*.{js,jsx,json,md,yml,yaml,html,graphql}\"",
-    "lint": "eslint --ext jsx,js ."
+    "lint": "eslint --ext jsx,js .",
+    "coverage": "jest --coverage"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
In the future, I would like to do the following:

* On CircleCI, Run `npm run coverage` and upload the coverage result to [codecov](https://codecov.io/) (a service for coverage visualization)
* Show coverage badge on README.md

I have sent a request to chingu admin so that I can use `codecov` in our project.