### PR TITLE
Fix security hole in GraphQL API

### DIFF
--- a/client/lib/init-apollo.js
+++ b/client/lib/init-apollo.js
@@ -37,7 +37,8 @@ function create(initialState) {
           headers: {
             ...headers,
             authorization:
-              headers.authorization || (token ? `Bearer ${token}` : "")
+              (headers && headers.authorization) ||
+              (token ? `Bearer ${token}` : "")
           }
         };
       }),

--- a/client/lib/init-apollo.js
+++ b/client/lib/init-apollo.js
@@ -31,13 +31,13 @@ function create(initialState) {
         }
       }),
       setContext((_, { headers }) => {
-        // get the authentication token from local storage if it exists
         const token = Cookie.get("token");
         // return the headers to the context so httpLink can read them
         return {
           headers: {
             ...headers,
-            authorization: token ? `Bearer ${token}` : ""
+            authorization:
+              headers.authorization || (token ? `Bearer ${token}` : "")
           }
         };
       }),

--- a/server/graphql/middleware.js
+++ b/server/graphql/middleware.js
@@ -1,0 +1,7 @@
+export const authenticated = next => (root, args, context, info) => {
+  if (!context.user.isLoggedIn) {
+    throw new Error(`Unauthenticated!`);
+  }
+
+  return next(root, args, context, info);
+};

--- a/server/graphql/schema.js
+++ b/server/graphql/schema.js
@@ -8,6 +8,7 @@ import {
 import jwt from "jsonwebtoken";
 
 import { User } from "../models/user";
+import { authenticated } from "./middleware";
 
 const UserType = new GraphQLObjectType({
   name: "User",
@@ -31,9 +32,9 @@ const RootQuery = new GraphQLObjectType({
     user: {
       type: UserType,
       args: { id: { type: GraphQLID } },
-      resolve(parent, args) {
+      resolve: authenticated((parent, args) => {
         return User.findById(args.id);
-      }
+      })
     },
     login: {
       type: AuthDataType,

--- a/server/graphql/schema.js
+++ b/server/graphql/schema.js
@@ -42,7 +42,7 @@ const RootQuery = new GraphQLObjectType({
         email: { type: GraphQLString },
         password: { type: GraphQLString }
       },
-      resolve: async (parent, { email, password }) => {
+      resolve: async (parent, { email, password }, { SECRET_KEY }) => {
         const user = await User.findOne({ email });
         if (!user) {
           throw new Error("Invalid credential");
@@ -51,7 +51,7 @@ const RootQuery = new GraphQLObjectType({
         if (user.password !== password) {
           throw new Error("Invalid credential");
         }
-        const token = jwt.sign({ id: user.id, email: user.email }, "secret", {
+        const token = jwt.sign({ id: user.id, email: user.email }, SECRET_KEY, {
           expiresIn: "1h"
         });
         return { token };

--- a/server/graphql/server.js
+++ b/server/graphql/server.js
@@ -13,16 +13,11 @@ function getUser(token, secretKey) {
   return user;
 }
 
-const PUBLIC_OPERATIONS = ["login", "addUser"];
-
 export function createApolloServer(secretKey) {
   const context = ({ req }) => {
     const contextObj = {};
     const token = req.headers.authorization || "";
     const user = getUser(token, secretKey);
-    if (!PUBLIC_OPERATIONS.includes(req.body.operationName) && !user.loggedIn) {
-      throw new Error("you must be logged in");
-    }
     contextObj.user = user;
     contextObj.SECRET_KEY = secretKey;
     return contextObj;

--- a/server/graphql/server.js
+++ b/server/graphql/server.js
@@ -3,7 +3,7 @@ import jwt from "jsonwebtoken";
 
 import { schema } from "./schema";
 
-function getUser(token, secretKey) {
+export function getUser(token, secretKey) {
   const user = { loggedIn: true };
   try {
     jwt.verify(token, secretKey);
@@ -13,14 +13,28 @@ function getUser(token, secretKey) {
   return user;
 }
 
+export function extractToken(authorization) {
+  const authHeader = authorization || "";
+  let token = "";
+  if (authHeader !== "") {
+    const authHeaderElements = authHeader.split(" ");
+    if (authHeaderElements.length === 2) {
+      token = authHeaderElements[1];
+    }
+  }
+  return token;
+}
+
+export const createContext = secretKey => ({ req }) => {
+  const contextObj = {};
+  const token = extractToken(req.headers.authorization);
+  const user = getUser(token, secretKey);
+  contextObj.user = user;
+  contextObj.SECRET_KEY = secretKey;
+  return contextObj;
+};
+
 export function createApolloServer(secretKey) {
-  const context = ({ req }) => {
-    const contextObj = {};
-    const token = req.headers.authorization || "";
-    const user = getUser(token, secretKey);
-    contextObj.user = user;
-    contextObj.SECRET_KEY = secretKey;
-    return contextObj;
-  };
+  const context = createContext(secretKey);
   return new ApolloServer({ schema, context });
 }

--- a/server/graphql/server.test.js
+++ b/server/graphql/server.test.js
@@ -1,0 +1,35 @@
+import jwt from "jsonwebtoken";
+
+import { getUser, extractToken } from "./server";
+
+describe("getUser", () => {
+  it("returns user object with loggedIn set to true when correct secret key is used", () => {
+    const token = jwt.sign({ id: 1, email: "foo@foo.com" }, "secret");
+    const user = getUser(token, "secret");
+    expect(user.loggedIn).toBe(true);
+  });
+
+  it("returns user object with loggedIn set to false when wrong secret key is used", () => {
+    const token = jwt.sign({ id: 1, email: "foo@foo.com" }, "secret");
+    const user = getUser(token, "wrong secret");
+    expect(user.loggedIn).toBe(false);
+  });
+});
+
+describe("extractToken", () => {
+  it("returns empty string if authorization header is undefined", () => {
+    expect(extractToken(undefined)).toBe("");
+  });
+
+  it("returns empty string if authorization header exists but is empty", () => {
+    expect(extractToken("")).toBe("");
+  });
+
+  it("returns empty string if authorization header exists but without actual token", () => {
+    expect(extractToken("Bearer ")).toBe("");
+  });
+
+  it("returns JTWT token if authorization header is of the form 'Bearer JWT_TOKEN'", () => {
+    expect(extractToken("Bearer JWT_TOKEN")).toBe("JWT_TOKEN");
+  });
+});


### PR DESCRIPTION
- Previously you needed to whitelist public GraphQL operations but now you will have to wrap resolver object with `authenticated` middleware to guard it against non-loggedin users. It turned out that `req.body.operationName` does not refer to the query type name but it is literally a operation name.

   For example in the query below, operation name is `login` so even if query type name is `user`, users were able to call it.
  ```graphql
   query login {
      user {
        email
      }
   }
    ```
- GraphQL requests by authenticated users also work with SSR
- Fix a bug of JWT token not properly extracted

Fixes #55 