### PR TITLE
Changed test environment to node for this file - default was JSDOM - Eliminates Mongoose-Jest Warning

### DIFF
--- a/server/graphql/server.test.js
+++ b/server/graphql/server.test.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import jwt from "jsonwebtoken";
 
 import { getUser, extractToken } from "./server";


### PR DESCRIPTION
Fixes #56 

Per the recommendation from Jest docs, I added the following docblock at the top of the `server/graphql/server.test.js` file.
```
/**
 * @jest-environment node
 */
```
https://jestjs.io/docs/en/configuration#testenvironment-string